### PR TITLE
fix(sorting): Fixes the return type being ordered by selector, not position in document

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -29,14 +29,12 @@ function plugin(options){
       var $ = cheerio.load(contents);
       data.headings = [];
 
-      selectors.forEach(function(s){
-        $(s).each(function(){
+        $(selectors.join(',')).each(function(){
           data.headings.push({
             id: $(this).attr('id'),
             tag: $(this)[0].name,
             text: $(this).text()
           });
-        });
       });
     });
   };

--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "version": "0.1.0",
   "license": "MIT",
   "main": "lib/index.js",
+  "scripts": {
+    "test": "mocha --reporter spec"
+  },
   "dependencies": {
     "cheerio": "^0.14.0"
   },

--- a/test/fixture/build/index.html
+++ b/test/fixture/build/index.html
@@ -1,4 +1,5 @@
 <h1 id="one-one">one one</h1>
 <h2 id="two-one">two one</h2>
+<h1 id="one-two">one two</h1>
 <h2 id="two-two">two two</h2>
 <h3 id="three">three</h3>

--- a/test/fixture/src/index.md
+++ b/test/fixture/src/index.md
@@ -3,6 +3,8 @@
 
 ## two one
 
+# one two
+
 ## two two
 
 ### three

--- a/test/index.js
+++ b/test/index.js
@@ -32,4 +32,20 @@ describe('metalsmith-headings', function(){
         done();
       });
   });
+
+  it('should preserve order with multiple selectors', function(done){
+    Metalsmith('test/fixture')
+      .use(markdown())
+      .use(headings({ selectors: ['h1', 'h2']}))
+      .build(function(err, files){
+        if (err) return done(err);
+        assert.deepEqual(files['index.html'].headings, [
+          { id: 'one-one', tag: 'h1', text: 'one one' },
+          { id: 'two-one', tag: 'h2', text: 'two one' },
+          { id: 'one-two', tag: 'h1', text: 'one two' },
+          { id: 'two-two', tag: 'h2', text: 'two two' }
+        ]);
+        done();
+      });
+  });
 });


### PR DESCRIPTION
This changes the selection so the matches are returned in their natural order from the document, not the order that the selectors were listed.

Now it is possible to make multi level menus.
Example with handlebars:
Metalsmith config:

``` js
Metalsmith('test/fixture')
      .use(markdown())
      .use(headings({ selectors: ['h2', 'h3']}))
      .build();
```

Template:

``` hbs
<ul class="section table-of-contents">
      {{#each headings }}
          <li><a href="#{{ id }}">{{{ifEqual tag 'h3' '&emsp;' }}}# {{ text }}</a></li>
      {{/each}}   
</ul>
```

Outputs:

``` md
# Getting started
# Adding pages
 # Collections
 # Templates & Partials
 # Styles & Assets
 # Variables
# TypeDoc
# Deployment
 # Config
 # Travis CI
# Plugins
```

Closes #4 
